### PR TITLE
Fix bot not recognising listings that end with a non-word character

### DIFF
--- a/commands/listing.js
+++ b/commands/listing.js
@@ -8,7 +8,7 @@ module.exports = {
     add: {
       usage: 'listing add [item]:[price] @[seller name]',
       description: 'Add a new listing',
-      argsPattern: /(?<item>[^:]+\b)\s*:\s*(?<price>[^@]+?)\s*(?=@(?<sellerName>.+)|$)/,
+      argsPattern: /(?<item>[^:]+[^\s])\s*:\s*(?<price>[^@]+?)\s*(?=@(?<sellerName>.+)|$)/,
       execute(args, user) {
         if (!args.sellerName && !user.defaultSeller) {
           return Promise.resolve({ message: "You need to specify a seller to add this listing to." });


### PR DESCRIPTION
Regex was matching up until a word boundary, and would fail to match if a listing ended in a non-word character. This changes it to allow anything up until a colon but it cannot end with spaces.