### PR TITLE
Change how sellers are specified when adding a listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ A listing is an item or service for a price. They belong to sellers and can be s
 
 To add a listing, a user needs to specify what is being sold, how much for, and where:
 
-**Usage:** `!cat listing add [:item]: [:price] @[:seller name]`\
-**Example:** `!cat listing add 5 books: 1 gold @My Shop`
+**Usage:** `!cat listing add [:item]: [:price] > [:seller name]`\
+**Example:** `!cat listing add 5 books: 1 gold > My Shop`
 
 Some things to note:
 
-* If a user has set a default seller then they can omit the `@[:seller name]`
-* Default seller can be overridden per listing by passing a different seller using `@[:seller name]`
+* If a user has set a default seller then they can omit the `> [:seller name]`
+* Default seller can be overridden per listing by passing a different seller using `> [:seller name]`
 
 ### Searching listings
 

--- a/commands/listing.js
+++ b/commands/listing.js
@@ -6,9 +6,9 @@ module.exports = {
   description: "A listing is an item or service for a price. Listings belong to sellers",
   subCommands: {
     add: {
-      usage: 'listing add [item]:[price] @[seller name]',
+      usage: 'listing add [item]:[price] > [seller name]',
       description: 'Add a new listing',
-      argsPattern: /(?<item>[^:]+[^\s])\s*:\s*(?<price>[^@]+?)\s*(?=@(?<sellerName>.+)|$)/,
+      argsPattern: /(?<item>[^:]+[^\s])\s*:\s*(?<price>.+?)\s*(?=>\s*(?<sellerName>.+)|$)/,
       execute(args, user) {
         if (!args.sellerName && !user.defaultSeller) {
           return Promise.resolve({ message: "You need to specify a seller to add this listing to." });


### PR DESCRIPTION
Currently, a seller is specified in listing creation using `@[seller name]`. This wasn't a great decision as typing `@` in Discord, as it does in similar apps, will bring up a dropdown containing a list of people you may want to tag/mention. This makes things confusing.

This changes it to use `>` instead.

**Was:**

`!cat listing add item : price @shop`

**Now:**

`!cat listing add item : price > shop`