### PR TITLE
Improve disallowing the ":" character

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ All that's needed to add a seller is a name.
 **Usage:** `!cat seller add [:name]`\
 **Example:** `!cat seller add My Shop`
 
+Something to note:
+
+* The seller name cannot contain the "`:`" character
+
 ### Listing sellers
 
 **Usage:** `!cat seller list`
@@ -132,6 +136,7 @@ Some things to note:
 
 * If a user has set a default seller then they can omit the `> [:seller name]`
 * Default seller can be overridden per listing by passing a different seller using `> [:seller name]`
+* The item and price cannot contain the "`:`" character
 
 ### Searching listings
 

--- a/cat_modules/validator.js
+++ b/cat_modules/validator.js
@@ -25,26 +25,34 @@ exports.run = (input, commands, userIsAmin) => {
       };
     }
 
-    // Check if args contains multiple colons
-    if ((input.args.match(/:/g) || []).length > 1) {
-      return {
-        message: 'The character "`:`" is reserved for internal use and cannot exist outside of the separator.'
-      };
-    }
+    if (subCommand.argsPattern) {
+      const args = input.args.match(subCommand.argsPattern);
 
-    // Check if sub-command matches the expected pattern
-    const args = input.args.match(subCommand.argsPattern);
+      // Check if given args matched the expected args pattern
+      if (!args) {
+        return {
+          message: `Here's how you use that \`${prefix} ${subCommand.usage}\`.`
+        };
+      }
 
-    if (!args) {
+      // Check if any of the arg groups contain a colon
+      if (Object.values(args.groups).some(arg => arg && arg.includes(':'))) {
+        return {
+          message: 'The character "`:`" is reserved for internal use and cannot exist outside of the separator.'
+        };
+      }
+
+      // All good
       return {
-        message: `Here's how you use that \`${prefix} ${subCommand.usage}\`.`
+        success: true,
+        args: args.groups,
+        command: subCommand
       };
     }
 
     // All good
     return {
       success: true,
-      args: args.groups,
       command: subCommand
     };
   }


### PR DESCRIPTION
"`:`" is used to handle inputs and a previous commit added a validation to prevent it from being used outside of where it was expected to be. The validation was simply checking if more than one colon was present in the input, but this isn't a good solution. One example of why it's not would be when adding a new seller - this command does not use a colon so one may be used as part of the seller name without the bot rejecting it, then when it comes to adding a listing to this seller - which does use a colon - the bot will reject it because there will be two colons in the input.

The second attempt to solve this involves running the check against the already separated/grouped args where the presence of any colons would result in rejection.